### PR TITLE
Add support for Binding to Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ and require it from your project:
 const rarbgApi = require('rarbg-api')
 ```
 
+# Environment Flags
+#### **NODE_ENV**
+- Can be set to `debug` to see debug messages and errors
+#### **LOCAL_ADDRESS**
+- Can be set to a network interface ip address in order to send requests from that source
+- See [http.request.options](https://nodejs.org/api/http.html#http_http_request_url_options_callback) for more details
+
+    
+
 # API
 
 ### .list([options: Object]): Array

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,14 +43,14 @@ function r(url, options) {
     const qs = options ? `?${querystring.stringify(options)}` : ''
     const finalUrl = `${url}${qs}`
     debug.log(`request url: ${finalUrl}`)
-    let options = {
+    let requestOptions = {
       headers: {
         'User-Agent': UA
       },
     };
     if(process.env.LOCAL_ADDRESS) 
-      options.localAddress = process.env.LOCAL_ADDRESS;
-    const req = https.request(Object.assign(parseUrl(finalUrl), options), res => {
+      requestOptions.localAddress = process.env.LOCAL_ADDRESS;
+    const req = https.request(Object.assign(parseUrl(finalUrl), requestOptions), res => {
       let body = ''
       res.on('data', chunk => {
         body += chunk

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,11 +43,14 @@ function r(url, options) {
     const qs = options ? `?${querystring.stringify(options)}` : ''
     const finalUrl = `${url}${qs}`
     debug.log(`request url: ${finalUrl}`)
-    const req = https.request(Object.assign(parseUrl(finalUrl), {
+    let options = {
       headers: {
         'User-Agent': UA
-      }
-    }), res => {
+      },
+    };
+    if(process.env.LOCAL_ADDRESS) 
+      options.localAddress = process.env.LOCAL_ADDRESS;
+    const req = https.request(Object.assign(parseUrl(finalUrl), options), res => {
       let body = ''
       res.on('data', chunk => {
         body += chunk

--- a/src/utils.js
+++ b/src/utils.js
@@ -99,6 +99,10 @@ function request(url, options) {
         return sleep(2).then(() => request(url, options))
       }
       return res
+    } else if (!res.body) {
+      // Too many requests per second
+      debug.warn(`too many request`)
+      return sleep(2).then(() => request(url, options))
     } else {
       return res
     }


### PR DESCRIPTION
The Backoff Trigger commit is referenced in #2 

The binding interface commit adds support for sending requests from different network interfaces. Specify the environment flag the internal IP address of a different network interface and requests to the API will be sent from that interface.