### PR TITLE
align categories and include missing one

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -2,9 +2,9 @@ const BASE_URL = 'https://torrentapi.org/pubapi_v2.php'
 const APP_ID = 'rarbg-api-nodejs'
 const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36'
 const CATEGORY = {
-  '4K_MOVIES_X264_4k': [50],
-  '4K_X265_4k': [51],
-  '4k_X264_4k_HDR': [52],
+  '4K_MOVIES_X264_4k': [50], // left for compatibility reasons
+  '4K_X265_4k': [51], // left for compatibility reasons
+  '4k_X264_4k_HDR': [52], // left for compatibility reasons
   XXX: [4],
   MOVIES_XVID: [14],
   MOVIES_XVID_720P: [48],
@@ -12,6 +12,10 @@ const CATEGORY = {
   MOVIES_X264_1080P: [44],
   MOVIES_X264_720P: [45],
   MOVIES_X264_3D: [47],
+  MOVIES_X264_4K: [50],
+  MOVIES_X265_1080P: [54],
+  MOVIES_X265_4K: [51],
+  MOVIES_X265_4K_HDR: [52],
   MOVIES_FULL_BD: [42],
   MOVIES_BD_REMUX: [46],
   TV_EPISODES: [18],


### PR DESCRIPTION
 - Leaves old 4k categories for compatibility reasons
 - Includes missing `MOVIES_X265_1080P`
 - Aligns 4k categories with original naming format, so that when choosing `MOVIES` 4k categories would be included as well